### PR TITLE
fix(test): pin vertical null space in the plane-stress patch test

### DIFF
--- a/tests/unit/demos/controlled_pendulum/fem/test_plane_stress.py
+++ b/tests/unit/demos/controlled_pendulum/fem/test_plane_stress.py
@@ -21,14 +21,12 @@ from ngsolve import (  # noqa: E402
     CF,
     BilinearForm,
     GridFunction,
-    H1,
     Integrate,
     Mesh,
-    VectorH1,
     Variation,
+    VectorH1,
     dx,
     x,
-    y,
 )
 from ngsolve.solvers import NewtonMinimization  # noqa: E402
 
@@ -44,13 +42,16 @@ MATERIALS = [NeoHookeanMaterial, SVKMaterial]
 
 def _make_patch_mesh(maxh: float = 0.3) -> Mesh:
     rect = Rectangle(1, 1).Face()
-    # Tag left edge as "left", right edge as "right" for Dirichlet BCs
+    # Tag left/right edges for the u_x Dirichlet data and the bottom edge for
+    # the u_y constraint that removes the vertical rigid-translation mode.
     for edge in rect.edges:
         p = edge.center
         if abs(p.x) < 1e-6:
             edge.name = "left"
         elif abs(p.x - 1.0) < 1e-6:
             edge.name = "right"
+        elif abs(p.y) < 1e-6:
+            edge.name = "bottom"
     geo = OCCGeometry(rect, dim=2)
     return Mesh(geo.GenerateMesh(maxh=maxh))
 
@@ -59,7 +60,11 @@ def _make_patch_mesh(maxh: float = 0.3) -> Mesh:
 def test_uniaxial_tension_patch(Material):
     """Stretch a 1×1 square along x and recover σ_xx ≈ E·ε.
 
-    Left edge: u_x = 0 (free in y). Right edge: u_x = ε, free in y.
+    Left edge: u_x = 0. Right edge: u_x = ε. Bottom edge: u_y = 0 — the exact
+    uniaxial field u = (εx, -νεy) satisfies this, so the constraint only pins
+    the vertical rigid-translation null space (without it the strain energy is
+    translation-invariant in y, the tangent is singular, and Newton may
+    diverge depending on round-off).
     The resulting field is uniaxial tension with lateral contraction determined
     by minimization of the strain energy — for plane stress this gives
     σ_yy ≈ 0 and σ_xx ≈ E·ε at small strain.
@@ -69,9 +74,9 @@ def test_uniaxial_tension_patch(Material):
 
     eps = 1e-5
 
-    fes = VectorH1(mesh, order=2, dirichletx="left|right")
+    fes = VectorH1(mesh, order=2, dirichletx="left|right", dirichlety="bottom")
     u = GridFunction(fes)
-    # Prescribe x-displacement on Dirichlet boundaries; y is free.
+    # Prescribe x-displacement on Dirichlet boundaries; u_y = 0 on the bottom.
     u.components[0].Set(CF(0.0), definedon=mesh.Boundaries("left"))
     u.components[0].Set(CF(eps), definedon=mesh.Boundaries("right"))
     # Quick-and-dirty: use linear interpolation as initial guess in x.


### PR DESCRIPTION
## Summary

Follow-up to #4: fixes the two `test-fem` failures (`test_uniaxial_tension_patch[NeoHookeanMaterial/SVKMaterial]`) that were still failing when #4 merged.

**Root cause** — a well-posedness defect in the pre-existing patch test, first exposed when the new `test-fem` CI job started actually executing it: the FE space constrained only the x-component (`dirichletx="left|right"`), leaving the **vertical rigid-translation mode unconstrained**. The strain energy is invariant under that mode, so the Newton tangent is singular and convergence depends on round-off — locally the solve limped through with a warning; on the CI runner it diverged to ~1e15 (NeoHookean) / ~1e90 (SVK) and produced garbage stresses.

**Fix** — tag the bottom edge of the patch and constrain `u_y = 0` there (`dirichlety="bottom"`). The exact uniaxial solution `u = (εx, −νεy)` satisfies `u_y = 0` at `y = 0`, so the constraint removes *only* the null space without perturbing the patch solution; rotations were already excluded by the `u_x` data on the left/right edges. Also drops two pre-existing unused imports flagged by ruff.

## Testing

- Verified with the CI-identical pip `ngsolve 6.2.2606`, across `OMP_NUM_THREADS ∈ {1, 2, 4}` and repeated runs: `2 passed` every time, and the previous "Newton might not converge" warnings are gone.
- Full `pytest -m fem` suite (32 tests) passes locally under the CI-equivalent environment (ngsolve installed, opensim absent).

This is the one commit needed to turn `main`'s `test-fem` job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBt93FHrcvfrkc4gstfqF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBt93FHrcvfrkc4gstfqF5)_